### PR TITLE
Use LinkedHashMap to fix flaky tests

### DIFF
--- a/nifi-commons/nifi-site-to-site-client/src/test/java/org/apache/nifi/remote/client/http/TestHttpClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/test/java/org/apache/nifi/remote/client/http/TestHttpClient.java
@@ -87,8 +87,8 @@ import java.net.ServerSocket;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -600,7 +600,7 @@ public class TestHttpClient {
     }
 
     private static class DataPacketBuilder {
-        private final Map<String, String> attributes = new HashMap<>();
+        private final Map<String, String> attributes = new LinkedHashMap<>();
         private String contents;
 
         private DataPacketBuilder attr(final String k, final String v) {
@@ -803,7 +803,7 @@ public class TestHttpClient {
     private void testSend(SiteToSiteClient client) throws Exception {
 
         testSendIgnoreProxyError(client, transaction -> {
-            serverChecksum = "1071206772";
+            serverChecksum = "40272532";
 
             for (int i = 0; i < 20; i++) {
                 DataPacket packet = new DataPacketBuilder()
@@ -952,7 +952,7 @@ public class TestHttpClient {
     private static void testSendLargeFile(SiteToSiteClient client) throws IOException {
 
         testSendIgnoreProxyError(client, transaction -> {
-            serverChecksum = "1527414060";
+            serverChecksum = "2387509971";
 
             final int contentSize = 10_000;
             final StringBuilder sb = new StringBuilder(contentSize);
@@ -1067,7 +1067,7 @@ public class TestHttpClient {
 
             assertNotNull(transaction);
 
-            serverChecksum = "1071206772";
+            serverChecksum = "40272532";
 
 
             for (int i = 0; i < 20; i++) {
@@ -1101,7 +1101,7 @@ public class TestHttpClient {
 
             assertNotNull(transaction);
 
-            serverChecksum = "3882825556";
+            serverChecksum = "3203143366";
 
 
             for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
## Overview
The test `TestHttpClient#testSendSuccessHTTPS` failed when I run it with the nondex tool (https://github.com/TestingResearchIllinois/NonDex).
Since I touched a commonly used part in the code, I also fix the other tests in the class. 
<img width="761" alt="image" src="https://user-images.githubusercontent.com/33991357/186746118-038f860a-2eac-4248-a847-0a15c76cd3f7.png">

## Changes Made
The test sends out some information and checks if the contents sent are expected by checking the value from `CRC32`. The value would be affected by the sequence of the content. Since it was a `HashMap`, the sequence is not guaranteed. I change it to `LinkedHashMap` to make sure the sequence is the same every time even with different random seeds. Since the sequence I set is different from the original default sequence, I need to change the `CRC32` value to match it.